### PR TITLE
Implement EntityTag id in spawn eggs

### DIFF
--- a/src/main/java/io/github/queerbric/inspecio/tooltip/SpawnEntityTooltipComponent.java
+++ b/src/main/java/io/github/queerbric/inspecio/tooltip/SpawnEntityTooltipComponent.java
@@ -30,9 +30,9 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
 
 import java.util.Optional;
-import java.util.UUID;
 
 public class SpawnEntityTooltipComponent extends EntityTooltipComponent {
 	private final Entity entity;
@@ -58,6 +58,19 @@ public class SpawnEntityTooltipComponent extends EntityTooltipComponent {
 				villagerData.putInt("level", 1);
 				villagerData.putString("type", "minecraft:plains");
 				itemEntityNbt.put("VillagerData", villagerData);
+			}
+			if (itemEntityNbt.contains("id", NbtElement.STRING_TYPE)) {
+				var id = itemEntityNbt.getString("id");
+				id = id.replaceAll("[^a-z0-9/._-]", "");
+				itemEntityNbt.putString("id", id);
+				Optional<EntityType<?>> entityTypeOptional = EntityType.fromNbt(itemEntityNbt);
+				if (entityTypeOptional.isPresent()) {
+					var entity2 = entityTypeOptional.get().create(client.world);
+					if (entity2 != null) {
+						entity = entity2;
+						adjustEntity(entity, itemNbt, entitiesConfig);
+					}
+				}
 			}
 			var entityTag = entity.writeNbt(new NbtCompound());
 			var uuid = entity.getUuid();


### PR DESCRIPTION
This allows you to see the entity that is actually going to be spawned and not that of the default spawn egg

For example this item:
`/give @s minecraft:creeper_spawn_egg{EntityTag:{id:"bee"}}`
![image](https://user-images.githubusercontent.com/63565983/127542144-f3961518-e643-4241-937e-64150c5ffead.png)


As this allows you to see tooltip of entities that are not spawn egg, you can see some that do not work:

### Invisible:
* area_effect_cloud
* evoker_fangs
* item
* marker

### They do not rotate:
* boat
* chest_minecart
* command_block_minecart
* dragon_fireball
* end_crystal
* ender_dragon
* falling_block
* furnace_minecart
* hopper_minecart
* leash_knot
* minecart
* painting
* spawner_minecart
* tnt

### Other visual bugs:
* chest_minecart
* command_block_minecart
* end_crystal
* falling_block
* furnace_minecart
* glow_item_frame
* hopper_minecart
* item_frame
* lightning_bolt
* minecart
* spawner_minecart
* tnt
* wither