### PR TITLE
Fix EntityTag id and EntityTag IsBaby/Small

### DIFF
--- a/src/main/java/io/github/queerbric/inspecio/tooltip/EntityTooltipComponent.java
+++ b/src/main/java/io/github/queerbric/inspecio/tooltip/EntityTooltipComponent.java
@@ -89,6 +89,9 @@ public abstract class EntityTooltipComponent implements ConvertibleTooltipData, 
 			size = 48;
 			yOffset = 28;
 		}
+		if (entity instanceof  LivingEntity && ((LivingEntity) entity).isBaby()) {
+			size /= 1.7;
+		}
 		matrices.translate(x + 10, y + yOffset, 1050);
 		matrices.scale(1f, 1f, -1);
 		matrices.translate(0, 0, 1000);

--- a/src/main/java/io/github/queerbric/inspecio/tooltip/EntityTooltipComponent.java
+++ b/src/main/java/io/github/queerbric/inspecio/tooltip/EntityTooltipComponent.java
@@ -89,7 +89,7 @@ public abstract class EntityTooltipComponent implements ConvertibleTooltipData, 
 			size = 48;
 			yOffset = 28;
 		}
-		if (entity instanceof  LivingEntity && ((LivingEntity) entity).isBaby()) {
+		if (entity instanceof LivingEntity living && living.isBaby()) {
 			size /= 1.7;
 		}
 		matrices.translate(x + 10, y + yOffset, 1050);

--- a/src/main/java/io/github/queerbric/inspecio/tooltip/SpawnEntityTooltipComponent.java
+++ b/src/main/java/io/github/queerbric/inspecio/tooltip/SpawnEntityTooltipComponent.java
@@ -59,17 +59,21 @@ public class SpawnEntityTooltipComponent extends EntityTooltipComponent {
 				villagerData.putString("type", "minecraft:plains");
 				itemEntityNbt.put("VillagerData", villagerData);
 			}
-			if (itemEntityNbt.contains("id", NbtElement.STRING_TYPE)) { // The spawn egg specifies its own entity type.
-				var id = itemEntityNbt.getString("id");
-				id = id.replaceAll("[^a-z0-9/._-]", "");
-				itemEntityNbt.putString("id", id);
-				Optional<EntityType<?>> specifiedEntityType = EntityType.fromNbt(itemEntityNbt);
-				if (specifiedEntityType.isPresent()) {
-					var actualEntity = specifiedEntityType.get().create(client.world);
-					if (actualEntity != null) {
-						entity = actualEntity;
-						adjustEntity(entity, itemNbt, entitiesConfig);
-					}
+			if (itemEntityNbt.contains(Entity.ID_KEY, NbtElement.STRING_TYPE)) { // The spawn egg specifies its own entity type.
+				var id = itemEntityNbt.getString(Entity.ID_KEY);
+				if (id.startsWith("minecraft:")) {
+					id = id.substring(10);
+				}
+				if (id.replaceAll("[^a-z0-9/._-]", "").matches(id)) {
+                    itemEntityNbt.putString(Entity.ID_KEY, id);
+                    Optional<EntityType<?>> specifiedEntityType = EntityType.fromNbt(itemEntityNbt);
+                    if (specifiedEntityType.isPresent()) {
+                        var actualEntity = specifiedEntityType.get().create(client.world);
+                        if (actualEntity != null) {
+                            entity = actualEntity;
+                            adjustEntity(entity, itemNbt, entitiesConfig);
+                        }
+                    }
 				}
 			}
 			var entityTag = entity.writeNbt(new NbtCompound());


### PR DESCRIPTION
* Fix tooltip not working EntityTag id that start with "minecraft:" and that takes as valid things like "zZombie" or "skeleton_"
* Fix that entities with the IsBaby tag do not look smaller

Before:
![image](https://user-images.githubusercontent.com/63565983/128262506-6cf6fbfc-6524-456a-b897-26114ce31b35.png)

After:
![image](https://user-images.githubusercontent.com/63565983/128262517-3c68258a-6987-41b6-b87d-d25192cdfbc6.png)

btw no idea what happened to the indentation, in IntelliJ IDEA it looks good