### PR TITLE
Fix OutOfBoundsException in Potion/TippedArrowItemMixin

### DIFF
--- a/src/main/java/io/github/queerbric/inspecio/Inspecio.java
+++ b/src/main/java/io/github/queerbric/inspecio/Inspecio.java
@@ -153,6 +153,18 @@ public class Inspecio implements ClientModInitializer {
 		}
 	}
 
+	public static void removeVanillaTooltips(List<Text> tooltips, int fromIndex) {
+		// TODO: currently O(n²)
+		while (tooltips.size() > fromIndex) {
+			Text removed = tooltips.remove(fromIndex);
+
+			// TODO: what is this for?
+			if (removed == LiteralText.EMPTY) {
+				break;
+			}
+		}
+	}
+
 	public static @Nullable Tag<Item> getHiddenEffectsTag() {
 		var tag = MinecraftClient.getInstance().world.getTagManager().getOrCreateTagGroup(Registry.ITEM_KEY).getTag(HIDDEN_EFFECTS_TAG);
 		if (tag == null) {

--- a/src/main/java/io/github/queerbric/inspecio/Inspecio.java
+++ b/src/main/java/io/github/queerbric/inspecio/Inspecio.java
@@ -154,15 +154,25 @@ public class Inspecio implements ClientModInitializer {
 	}
 
 	public static void removeVanillaTooltips(List<Text> tooltips, int fromIndex) {
-		// TODO: currently O(n²)
-		while (tooltips.size() > fromIndex) {
-			Text removed = tooltips.remove(fromIndex);
+		if (fromIndex >= tooltips.size()) return;
 
-			// TODO: what is this for?
-			if (removed == LiteralText.EMPTY) {
-				break;
+		int keepIndex = tooltips.indexOf(LiteralText.EMPTY);
+		if (keepIndex != -1) {
+			// we wanna keep tooltips that come after a line break
+			keepIndex++;
+
+			int tooltipsToKeep = tooltips.size() - keepIndex;
+
+			// shift tooltips to keep to the front
+			for (int i = 0; i < tooltipsToKeep; i++) {
+				tooltips.set(fromIndex + i, tooltips.get(keepIndex + i));
 			}
+
+			// don't remove them
+			fromIndex += tooltipsToKeep;
 		}
+
+		tooltips.subList(fromIndex, tooltips.size()).clear();
 	}
 
 	public static @Nullable Tag<Item> getHiddenEffectsTag() {

--- a/src/main/java/io/github/queerbric/inspecio/mixin/BlockItemMixin.java
+++ b/src/main/java/io/github/queerbric/inspecio/mixin/BlockItemMixin.java
@@ -57,7 +57,7 @@ public abstract class BlockItemMixin extends Item {
 		var inspecioConfig = Inspecio.get().getConfig();
 		var containersConfig = inspecioConfig.getContainersConfig();
 		var effectsConfig = inspecioConfig.getEffectsConfig();
-		 if (effectsConfig.hasBeacon() && this.getBlock() instanceof BeaconBlock) {
+		if (effectsConfig.hasBeacon() && this.getBlock() instanceof BeaconBlock) {
 			var blockEntityTag = stack.getOrCreateSubNbt(BlockItem.BLOCK_ENTITY_TAG_KEY);
 			var effectsList = new ArrayList<StatusEffectInstance>();
 			var primary = Inspecio.getRawEffectFromTag(blockEntityTag, "Primary");

--- a/src/main/java/io/github/queerbric/inspecio/mixin/PotionItemMixin.java
+++ b/src/main/java/io/github/queerbric/inspecio/mixin/PotionItemMixin.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 @Mixin(PotionItem.class)
 public abstract class PotionItemMixin extends Item {
 	@Unique
-	private final ThreadLocal<Integer> inspecio$oldTooltipLength = new ThreadLocal<>();
+	private final ThreadLocal<Integer> inspecio$oldTooltipLength = new ThreadLocal<>(); // ThreadLocal as REI workaround
 
 	public PotionItemMixin(Settings settings) {
 		super(settings);
@@ -54,14 +54,8 @@ public abstract class PotionItemMixin extends Item {
 
 	@Inject(method = "appendTooltip", at = @At("RETURN"))
 	private void onAppendTooltipPost(ItemStack stack, World world, List<Text> tooltip, TooltipContext context, CallbackInfo info) {
-		if (tooltip.size() > this.inspecio$oldTooltipLength.get() && Inspecio.get().getConfig().getEffectsConfig().hasPotions()) {
-			while (tooltip.size() > 1) {
-				if (tooltip.get(this.inspecio$oldTooltipLength.get()) == LiteralText.EMPTY) {
-					tooltip.remove(this.inspecio$oldTooltipLength.get().intValue());
-					break;
-				}
-				tooltip.remove(this.inspecio$oldTooltipLength.get().intValue());
-			}
+		if (Inspecio.get().getConfig().getEffectsConfig().hasPotions()) {
+			Inspecio.removeVanillaTooltips(tooltip, this.inspecio$oldTooltipLength.get());
 		}
 	}
 

--- a/src/main/java/io/github/queerbric/inspecio/mixin/TippedArrowItemMixin.java
+++ b/src/main/java/io/github/queerbric/inspecio/mixin/TippedArrowItemMixin.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 @Mixin(TippedArrowItem.class)
 public abstract class TippedArrowItemMixin extends Item {
 	@Unique
-	private final ThreadLocal<Integer> inspecio$oldTooltipLength = new ThreadLocal<>();
+	private final ThreadLocal<Integer> inspecio$oldTooltipLength = new ThreadLocal<>(); // ThreadLocal as REI workaround
 
 	public TippedArrowItemMixin(Settings settings) {
 		super(settings);
@@ -54,14 +54,8 @@ public abstract class TippedArrowItemMixin extends Item {
 
 	@Inject(method = "appendTooltip", at = @At("RETURN"))
 	private void onAppendTooltipPost(ItemStack stack, World world, List<Text> tooltip, TooltipContext context, CallbackInfo info) {
-		if (tooltip.size() > this.inspecio$oldTooltipLength.get() && Inspecio.get().getConfig().getEffectsConfig().hasTippedArrows()) {
-			while (tooltip.size() > 1) {
-				if (tooltip.get(this.inspecio$oldTooltipLength.get()) == LiteralText.EMPTY) {
-					tooltip.remove(this.inspecio$oldTooltipLength.get().intValue());
-					break;
-				}
-				tooltip.remove(this.inspecio$oldTooltipLength.get().intValue());
-			}
+		if (Inspecio.get().getConfig().getEffectsConfig().hasTippedArrows()) {
+			Inspecio.removeVanillaTooltips(tooltip, this.inspecio$oldTooltipLength.get());
 		}
 	}
 


### PR DESCRIPTION
I ran into this while messing around with tooltips, adding a second/sub name to items.
Looking at `PotionItemMixin` (which is basically the exact same as `TippedArrowItemMixin`)

https://github.com/Queerbric/Inspecio/blob/bdeaa062c48e8170c2450c16d431103c3fb2c2de/src/main/java/io/github/queerbric/inspecio/mixin/PotionItemMixin.java#L57-L65

If e.g. `tooltip.size()` is 3 and `oldTooltipLength` is 2, it'll enter the loop, remove the tooltip at index 2 and continue the loop since `tooltip.size() > 1`, it'll call `get` at the same index which fails since index 2 is now out of bounds.
Fix is to simply change the 1 to `oldTooltipLength`.

I rewrote the offending code but didn't quite finish it because I have a question:
Why does this removal loop `break` if a `LiteralText.EMPTY` is found?
Is this something for mod compat? Because this doesn't seem to happen in Vanilla at all and it seems much easier to e.g. redirect `PotionUtil.buildTooltip()` to do nothing.