### PR TITLE
Remove Advanced Tooltips Check (Fixes #81)

### DIFF
--- a/src/main/java/io/github/queerbric/inspecio/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/queerbric/inspecio/mixin/ItemStackMixin.java
@@ -77,10 +77,7 @@ public abstract class ItemStackMixin {
 
 	@Inject(
 			method = "getTooltip",
-			at = @At(
-					value = "INVOKE",
-					target = "Lnet/minecraft/item/ItemStack;isDamaged()Z"
-			)
+			at = @At(value = "RETURN")
 	)
 	private void onGetTooltip(PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir) {
 		var tooltip = this.inspecio$tooltipList.get();


### PR DESCRIPTION
Fixes #81 again. in-mixin check was removed, but not the vanilla one. 

![image](https://user-images.githubusercontent.com/55819817/181680005-4cdb6e73-8ced-42dc-9786-222d3a7d16e8.png)

Side effects:
This also makes lodestones show up without advanced (we're assuming this was intended)
repair cost and lodestone location show up **below** advanced tooltips, if they are enabled.
Could use `INVOKE` on `context.isAdvanced()` or `this.hasTag()` with an ordinal to resolve this, but that's less stable as far as we know. Feel free to edit.